### PR TITLE
Add environment variable for API host

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ docker-compose up -d
 ```bash
 sed -i \
   -e 's/VIRTUAL_HOST: api.tageler.ch/VIRTUAL_HOST: api.example.org/' \
+  -e 's/API_HOST: api.tageler.ch/API_HOST: api.example.org/' \
   -e 's/VIRTUAL_HOST: www.tageler.ch/VIRTUAL_HOST: www.example.org/' \
   docker-compose.yml
 ```
@@ -22,6 +23,7 @@ sed -i \
   -e 's@tageler/tageler-api:latest@tageler/tageler-api:develop@' \
   -e 's@tageler/tageler-frontend:latest@tageler/tageler-frontend:develop@' \
   -e 's/VIRTUAL_HOST: api.tageler.ch/VIRTUAL_HOST: api.tageler.vcap.me/' \
+  -e 's/API_HOST: api.tageler.ch/API_HOST: api.tageler.vcap.me/' \
   -e 's/VIRTUAL_HOST: www.tageler.ch/VIRTUAL_HOST: www.tageler.vcap.me/' \
   docker-compose.yml
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,4 @@ web:
    - api:api
   environment:
    VIRTUAL_HOST: www.tageler.ch
+   API_HOST: api.tageler.ch


### PR DESCRIPTION
Needs tageler/tageler-frontend#42 to work

Adds the environment variable API_HOST to the docker-compose.yml
Update the readme accordingly