### PR TITLE
Change mongodb volume mountpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   mongodb:
     image: mongo:latest
     volumes:
-     - "/var/lib/mongodb:/var/lib/mongodb"
+     - "/var/lib/mongo:/data/db"
     ports:
      - "27017:27017"
 


### PR DESCRIPTION
We are mounting the mongodb data folder to the wrong path within the docker container.
This commit remedies that, and will allow us to use SED to replace the path within the build chain.

Improves on #7