### PR TITLE
Add docker network config to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
      - "/var/lib/mongodb:/var/lib/mongodb"
     ports:
      - "27017:27017"
+    networks:
+     - tageler-network
 
   api:
     image: tageler/tageler-api:latest
@@ -13,6 +15,8 @@ services:
       - mongodb
     expose:
      - "3000"
+    networks:
+     - tageler-network
     environment:
      MONGODB_PORT_27017_TCP_ADDR: mongodb
      VIRTUAL_HOST: api.tageler.ch
@@ -24,5 +28,10 @@ services:
       - api
     expose:
       - "80"
+    networks:
+     - tageler-network
     environment:
      VIRTUAL_HOST: www.tageler.ch
+
+networks:
+  tageler-network:


### PR DESCRIPTION
This will allow us, to host multiple instances of the container on the same host, without interfering with each other.

Improves on #7 